### PR TITLE
Feat/better eli5 output

### DIFF
--- a/backend/adaboost_rf.py
+++ b/backend/adaboost_rf.py
@@ -5,10 +5,12 @@ import easyocr
 import numpy as np
 import cv2
 import json
+import re
 from joblib import load
 import torch
 from eli5.lime import TextExplainer
 from sklearn.feature_extraction.text import CountVectorizer
+from stopwordsiso import stopwords
 
 app = Flask(__name__)
 CORS(app)
@@ -17,6 +19,29 @@ CORS(app)
 loaded_model = load('./adaboost_rf_model.joblib')
 loaded_tokenizer = load("./tfidf_vectorizer.joblib")
 class_names = ["Fake News", "Real News"]
+
+# Prepare stopwords
+english_stopwords = stopwords("en")
+filipino_stopwords = stopwords("tl")
+combined_stopwords = english_stopwords.union(filipino_stopwords)
+
+# Normalize stopwords to match tokenization pattern
+def normalize_stopwords(stopwords_set):
+    token_pattern = re.compile(r"(?u)\b\w\w+\b")
+    return set([token for word in stopwords_set for token in token_pattern.findall(word.lower())])
+
+normalized_stopwords = normalize_stopwords(combined_stopwords)
+
+# Function to check if a feature contains only stopwords
+def is_stopword_feature(feature, stopwords_set):
+    """Check if a feature (word or phrase) consists only of stopwords or is a special token"""
+    # Filter out LIME special tokens
+    if feature in ['<BIAS>', '<UNK>', '<PAD>']:
+        return True
+    
+    tokens = feature.lower().split()
+    # If all tokens are stopwords, return True
+    return all(token in stopwords_set for token in tokens)
 
 # Wrap the model in a prediction function for LIME/ELI5
 def predict_proba(texts):
@@ -110,16 +135,18 @@ def process_text(text_input):
                 if hasattr(fw, 'pos') and hasattr(fw, 'neg'):
                     all_features = []
                     
-                    # Add positive features
+                    # Add positive features (filter stopwords)
                     for item in fw.pos:
                         if hasattr(item, 'feature') and hasattr(item, 'weight'):
-                            all_features.append((item.feature, item.weight))
+                            if not is_stopword_feature(item.feature, normalized_stopwords):
+                                all_features.append((item.feature, item.weight))
                     
-                    # Add negative features
+                    # Add negative features (filter stopwords)
                     for item in fw.neg:
                         if hasattr(item, 'feature') and hasattr(item, 'weight'):
-                            all_features.append((item.feature, item.weight))
-                    
+                            if not is_stopword_feature(item.feature, normalized_stopwords):
+                                all_features.append((item.feature, item.weight))
+                                
                     # Sort by absolute weight
                     sorted_features = sorted(
                         all_features, 

--- a/backend/distilmbert.py
+++ b/backend/distilmbert.py
@@ -5,6 +5,7 @@ import easyocr
 import numpy as np
 import cv2
 import json
+import re
 from transformers import (
     AutoTokenizer,
     AutoModelForSequenceClassification
@@ -12,6 +13,7 @@ from transformers import (
 import torch
 from eli5.lime import TextExplainer
 from sklearn.feature_extraction.text import CountVectorizer
+from stopwordsiso import stopwords
 
 app = Flask(__name__)
 CORS(app)
@@ -21,6 +23,29 @@ loaded_model = AutoModelForSequenceClassification.from_pretrained("./distilmbert
 loaded_tokenizer = AutoTokenizer.from_pretrained("./distilmbert")
 loaded_model.eval()
 class_names = ["Fake News", "Real News"]
+
+# Prepare stopwords
+english_stopwords = stopwords("en")
+filipino_stopwords = stopwords("tl")
+combined_stopwords = english_stopwords.union(filipino_stopwords)
+
+# Normalize stopwords to match tokenization pattern
+def normalize_stopwords(stopwords_set):
+    token_pattern = re.compile(r"(?u)\b\w\w+\b")
+    return set([token for word in stopwords_set for token in token_pattern.findall(word.lower())])
+
+normalized_stopwords = normalize_stopwords(combined_stopwords)
+
+# Function to check if a feature contains only stopwords
+def is_stopword_feature(feature, stopwords_set):
+    """Check if a feature (word or phrase) consists only of stopwords or is a special token"""
+    # Filter out LIME special tokens
+    if feature in ['<BIAS>', '<UNK>', '<PAD>']:
+        return True
+    
+    tokens = feature.lower().split()
+    # If all tokens are stopwords, return True
+    return all(token in stopwords_set for token in tokens)
 
 # Wrap the model in a prediction function for LIME/ELI5
 def predict_proba(texts):
@@ -115,15 +140,17 @@ def process_text(text_input):
                 if hasattr(fw, 'pos') and hasattr(fw, 'neg'):
                     all_features = []
                     
-                    # Add positive features
+                    # Add positive features (filter stopwords)
                     for item in fw.pos:
                         if hasattr(item, 'feature') and hasattr(item, 'weight'):
-                            all_features.append((item.feature, item.weight))
+                            if not is_stopword_feature(item.feature, normalized_stopwords):
+                                all_features.append((item.feature, item.weight))
                     
-                    # Add negative features
+                    # Add negative features (filter stopwords)
                     for item in fw.neg:
                         if hasattr(item, 'feature') and hasattr(item, 'weight'):
-                            all_features.append((item.feature, item.weight))
+                            if not is_stopword_feature(item.feature, normalized_stopwords):
+                                all_features.append((item.feature, item.weight))
                     
                     # Sort by absolute weight
                     sorted_features = sorted(

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -70,6 +70,7 @@ shapely==2.1.1
 six==1.17.0
 slicer==0.0.8
 sniffio==1.3.1
+stopwordsiso==0.6.1
 sympy==1.14.0
 tabulate==0.9.0
 tenacity==8.5.0


### PR DESCRIPTION
This pull request introduces filtering of stopwords from model explanation outputs in both the `adaboost_rf.py` and `distilmbert.py` backend scripts, improving the interpretability of feature importance by excluding uninformative tokens. It does so by integrating the `stopwordsiso` package for comprehensive English and Filipino stopwords coverage, normalizing these stopwords, and filtering them out of the LIME/ELI5 explanation features.

**Stopwords filtering and normalization:**

* Added `stopwordsiso` as a dependency and imported it in both `adaboost_rf.py` and `distilmbert.py` for access to English and Filipino stopwords. [[1]](diffhunk://#diff-b0db433d46d553f1d85e6b17569785546ceaf743dffca328c8a1d41a2ceda921R8-R13) [[2]](diffhunk://#diff-7c992688dde06589c4e87ea9e1e132317bbcb2d1322c7ecd5778bff63736fcaaR8-R16) [[3]](diffhunk://#diff-a780f027052bed3bff6ce9850db4a0e66358b86503cf4586e846ce88afa2e9bcR73)
* Combined and normalized stopwords from both languages to match the tokenization pattern used in feature extraction. [[1]](diffhunk://#diff-b0db433d46d553f1d85e6b17569785546ceaf743dffca328c8a1d41a2ceda921R23-R45) [[2]](diffhunk://#diff-7c992688dde06589c4e87ea9e1e132317bbcb2d1322c7ecd5778bff63736fcaaR27-R49)
* Implemented the `is_stopword_feature` function to check if a feature consists only of stopwords or is a special token, and used this to filter out such features from both positive and negative feature lists in the model explanations. [[1]](diffhunk://#diff-b0db433d46d553f1d85e6b17569785546ceaf743dffca328c8a1d41a2ceda921R23-R45) [[2]](diffhunk://#diff-7c992688dde06589c4e87ea9e1e132317bbcb2d1322c7ecd5778bff63736fcaaR27-R49) [[3]](diffhunk://#diff-b0db433d46d553f1d85e6b17569785546ceaf743dffca328c8a1d41a2ceda921L113-R147) [[4]](diffhunk://#diff-7c992688dde06589c4e87ea9e1e132317bbcb2d1322c7ecd5778bff63736fcaaL118-R152)